### PR TITLE
Version 6.111.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,6 +91,8 @@ about:
   doc_url: https://hypothesis.readthedocs.io/en/latest
 
 extra:
+  skip-lints:
+    - invalid_url
   recipe-maintainers:
     - ericmjl
     - jochym

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     #lark
     - lark >=0.10.1
     #numpy
-    - numpy >=1.17.3, <=2.0.1
+    - numpy >=1.17.3
     #pandas
     - pandas >=1.1
     #pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,7 +88,7 @@ about:
       simple and comprehensible examples that make your tests fail. This lets
       you find more bugs in your code with less work.
   dev_url: https://github.com/HypothesisWorks/hypothesis-python
-  doc_url: https://hypothesis.readthedocs.io/
+  doc_url: https://hypothesis.readthedocs.io/en/latest
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hypothesis" %}
-{% set version = "6.100.1" %}
+{% set version = "6.111.0" %}
 
 package:
   name: hypothesis
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ebff09d7fa4f1fb6a855a812baf17e578b4481b7b70ec6d96496210d1a4c6c35
+  sha256: 04d0703621d9fdd61c079a4dda07babbe7ebf6d34eee6ad9484a2af0ee721801
 
 build:
   number: 0
@@ -41,7 +41,7 @@ requirements:
     #lark
     - lark >=0.10.1
     #numpy
-    - numpy >=1.17.3
+    - numpy >=1.17.3, <=2.0.1
     #pandas
     - pandas >=1.1
     #pytest


### PR DESCRIPTION
hypothesis 6.111.0

**Destination channel:** defaults

### Links

- [PKG-5523](https://anaconda.atlassian.net/browse/PKG-5523) 
- [Upstream repository](https://github.com/HypothesisWorks/hypothesis-python)
- [Upstream changelog/diff](https://github.com/HypothesisWorks/hypothesis/commit/b38fe7a6e475008ff4341de2ae984aac8e5e9f43)
- Relevant dependency PRs:
  - numpy 2


### Explanation of changes:
- **Updated Hypothesis to version 6.111.0**:
  - Brings the project up to date with the latest features and improvements.
  - Addresses a critical dependency issue related to NumPy.

- **Resolved NumPy2 hotfix conflict**:
  - The main channel had a `<2.0` dependency for Hypothesis, causing a crash when attempting to test NumPy2.
  - This update allows Hypothesis to resolve correctly, enabling testing for NumPy2 without crashing.

- **Rationale for the update**:
  - Ensures that the project can successfully test against NumPy2 by eliminating conflicting dependencies.
  - Prevents potential issues and supports compatibility across dependencies.


[PKG-5523]: https://anaconda.atlassian.net/browse/PKG-5523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ