### PR TITLE
hypothesis 6.138.14 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     folder: gh_src
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,12 +31,12 @@ requirements:
     - attrs >=22.2.0
     - exceptiongroup >=1.0.0  # [py<311]
     - sortedcontainers >=2.1.0,<3.0.0
-  run_constrained:
       #-- cli tool
     - click >=7.0,!=8.2.2 # 8.2.2 was yanked
     - black >=20.8b0
     - rich >=9.0.0
       #--
+  run_constrained:
     - libcst >=0.3.16
     - pytz >=2014.1
     - python-dateutil >=1.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hypothesis" %}
-{% set version = "6.138.2" %}
+{% set version = "6.138.14" %}
 
 package:
   name: {{ name|lower }}
@@ -7,15 +7,15 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 82e3b2ac709ee3edda4aba2f4b11becfe764f51d104fcdb3e9f95aff1ac81595
+    sha256: 5c1aa1ce3f1094b5c04ea03476017695bda408a174330e5275e40ddd06d3307a
 
     # tests and tests data files
-  - url: https://github.com/HypothesisWorks/{{ name }}/archive/refs/tags/{{ name }}-python-{{ version }}.zip
-    sha256: af1c6b4b705de599718472436ab2cb4303296523e22301b02376474ad892c2b6
+  - url: https://github.com/HypothesisWorks/{{ name }}/archive/refs/tags/{{ name }}-python-{{ version }}.tar.gz
+    sha256: 54c4d22834341a15839e09d1defd2a3094332d231d45833de620ef718635092e
     folder: gh_src
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:


### PR DESCRIPTION
hypothesis 6.138.14 

**Destination channel:** Defaults

### Links

- [PKG-9525]
- dev_url:        https://github.com/hypothesisWorks/hypothesis/tree/hypothesis-python-6.138.14
- conda_forge:    https://github.com/conda-forge/hypothesis-feedstock
- pypi:           https://pypi.org/project/hypothesis/6.138.14
- pypi inspector: https://inspector.pypi.io/project/hypothesis/6.138.14

### Explanation of changes:

- move back cli to run from run_constrained
- update version to 6.138.14


[PKG-9525]: https://anaconda.atlassian.net/browse/PKG-9525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ