### PR TITLE
Rebuild against python 3.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,9 +91,10 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - hypothesis --help
-    - python -m pytest -v hypothesis-python/tests/cover -vv --color=yes -n auto --dist=loadscope --maxfail=1 --durations=25 -k "not ({{ skip_tests }})"
+    # Skip testing on python 3.14 once pandas will be rebuilt
+    - python -m pytest -v hypothesis-python/tests/cover -vv --color=yes -n auto --dist=loadscope --maxfail=1 --durations=25 -k "not ({{ skip_tests }})" # [py314]
   requires:
-    - pandas
+    - pandas # [py<314]
     - pip
     - pytest >=4.6
     - pytest-xdist

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,10 +64,11 @@ requirements:
 test:
   source_files:
     - hypothesis-python/tests
+  # Skip testing on python 3.14 once pandas will be rebuilt
   imports:
     - hypothesis
     - hypothesis.extra
-    - hypothesis.extra.pandas
+    - hypothesis.extra.pandas # [py<314]
     - hypothesis.internal
     - hypothesis.internal.conjecture
     - hypothesis.internal.conjecture.shrinking
@@ -91,7 +92,6 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - hypothesis --help
-    # Skip testing on python 3.14 once pandas will be rebuilt
     - python -m pytest -v hypothesis-python/tests/cover -vv --color=yes -n auto --dist=loadscope --maxfail=1 --durations=25 -k "not ({{ skip_tests }})" # [py314]
   requires:
     - pandas # [py<314]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cc4166fbefeb10ee750d5f9397276880c6cb6877183d23d7e0fb1af88c9ee0c5
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install ./hypothesis-python --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - hypothesis = hypothesis.extra.cli:main
@@ -99,7 +99,6 @@ test:
     - pytest-xdist
     - pexpect
     - click >=7.0,!=8.2.2 # 8.2.2 was yanked
-    - black >=20.8b0
     - rich >=9.0.0
 
 about:


### PR DESCRIPTION
[PKG-10423](https://anaconda.atlassian.net/browse/PKG-10423)

Rebuild against python 3.14

# Note
Skipping testing for python 3.14 until pandas is rebuilt

[PKG-10423]: https://anaconda.atlassian.net/browse/PKG-10423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ