### PR TITLE
fix(anaconda.yaml): PyPI upstream for hypothesis (PKG-14103)

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,8 +1,5 @@
 anaconda_config_version: 1
 upstream_sources:
-  - github:
-      identifier: hypothesisworks/hypothesis
-      use_max_tag: true
-      exclude_regex: (?i)^(?=.*(?:(?<=\d)rc\d*|(?<=\d)dev\d+|(?:^|[-._])(?:alpha|beta|gamma|pre|preview)(?:\d+)?|[-._]rc\d+|(?:^|[-._])dev\d+|(?:\d+\.)+\d+[ab]\d*)).+$
-      from_pattern: ^v?(\d+(?:\.\d+)*.*)$
-      to_pattern: \1
+  # PyPI is canonical for releases; distro-db may still list a GitHub homepage purl.
+  - pypi:
+      identifier: hypothesis


### PR DESCRIPTION
## Summary
Switch `upstream_sources[0]` to `pypi: hypothesis` so `anaconda.yaml` matches aggregate-duct-tape `github->pypi` policy and consumer PyPI-based version truth.

## Context
- **PKG-14103** (NVCHECKER / distro-db `override_transitions` for `github->pypi`).

## Note
The recipe still builds from a **GitHub archive URL**; this file is for **version discovery** only (nvchecker / dashboards).

Made with [Cursor](https://cursor.com)